### PR TITLE
Update URL for Refresh Token

### DIFF
--- a/lib/clients/refresh.js
+++ b/lib/clients/refresh.js
@@ -62,7 +62,7 @@ RefreshClient.prototype._refreshAccessToken = function() {
   var self = this;
   return new Promise(function(fulfill, reject) {
     request({
-      url: 'https://www.active911.com/interface/dev/api_access.php',
+      url: 'https://console.active911.com/interface/dev/api_access.php',
       method: 'POST',
       form: {
         'refresh_token': self._refreshToken


### PR DESCRIPTION
Currently, the URL for the Refresh token isn't correct, so the library isn't usable